### PR TITLE
Copy example set by SQLite and go public domain.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,20 +1,8 @@
-Copyright (c) oss/acc. Built with TailwindUI.com
+The author disclaims copyright to this source code.  In place of
+a legal notice, here is a blessing:
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+  *   May you do good and not evil.
+  *   May you find forgiveness for yourself and forgive others.
+  *   May you share freely, never taking more than you give.
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,7 +11,7 @@ export function Footer() {
         className="relative text-center text-sm text-slate-600"
       >
         <p>
-          MIT &copy; {new Date().getFullYear()} oss/acc – Source Code on GitHub
+          {new Date().getFullYear()} oss/acc – Source Code on GitHub
         </p>
       </a>
     </footer>


### PR DESCRIPTION
This change:

- Switches LICENSE.md to use the same one SQLite uses (https://sqlite.org/src/file?name=LICENSE.md&ci=trunk)

- Removes (c)opyright symbol.